### PR TITLE
fix a wrong queue data length

### DIFF
--- a/android_app/app/src/main/cpp/tcp.c
+++ b/android_app/app/src/main/cpp/tcp.c
@@ -956,6 +956,7 @@ void queue_tcp(const struct arguments *args,
                 free(s->data);
                 s->data = malloc(datalen);
                 memcpy(s->data, data, datalen);
+                s->len = datalen;
             } else
                 log_android(ANDROID_LOG_ERROR, "%s segment larger %u..%u < %u",
                             session,


### PR DESCRIPTION
Try this app and find a problem that when tcp windows scale is some value, connection will be always broken.
Reproduce the problem:
1. change tcp.c line 627
"s->tcp.recv_scale = ws;"  -> "s->tcp.recv_scale = 8;" //ws is from device init tcp header, some device is 8
2. Test it in android studio vitual device. chrome can't access any site.

