### PR TITLE
Improve package filtering

### DIFF
--- a/android_app/app/src/main/java/tun/proxy/SimplePreferenceFragment.java
+++ b/android_app/app/src/main/java/tun/proxy/SimplePreferenceFragment.java
@@ -244,6 +244,9 @@ public class SimplePreferenceFragment extends PreferenceFragment
 
             final Map<String, Boolean> installedPackageMap = new HashMap<>();
             for (final PackageInfo pi : installedPackages) {
+                if (pi.packageName.equals(MyApplication.getInstance().getPackageName())) {
+                    continue;
+                }
                 boolean checked = this.mAllPackageInfoMap.containsKey(pi.packageName) ? this.mAllPackageInfoMap.get(pi.packageName) : false;
                 installedPackageMap.put(pi.packageName, checked);
             }


### PR DESCRIPTION
1. TunProxy should not use its own VPN connection, it should be automatically added to disallowed packages and hidden from the preferences.
2. Fix the crash occurs on startup when some allowed/disallowed packages are deleted from the device (PackageManager.NameNotFoundException). These packages will be removed from package list.